### PR TITLE
Add Docker compose file for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,163 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Vim swap
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,8 @@ cython_debug/
 
 # Vim swap
 *.swp
+
+# Files
+*.gri
+*.h5
+*.epc

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Resqml ETP Cconnection experiment
+# Resqml ETP Connection experiment
 Python code to demonstrate creation and transfer of a RESQML object using Energistics Transfer Protocol (ETP).
 The code does the following:
-* convert a xtgeo .gri file to a RESQML Grid2dRepresentation object using [resqpy](https://github.com/bp/resqpy)
+* convert a `xtgeo` `.gri`-file to a RESQML Grid2dRepresentation object using [resqpy](https://github.com/bp/resqpy)
 * upload this RESQML object to a OSDU/RDDMS server using the ETP protocol. This uses a [modified version of the Geosiris ETP stack](https://github.com/equinor/etpclient-python/tree/modifications_for_Grid2d_test) (etpclient-python, etpproto-python, etptypes).
 * download the RESQML object from the RDDMS server using the ETP protocol.  This uses the same modified version of the Geosiris ETP stack (etpclient-python, etpproto-python, etptypes).
 * read the downloaded data using resqpy to complete the data round-trip.
 * assert that the round-tripped data is unchanged.
 
+
 ## Setup
-The setup sequence below is to be verified:
-- install resqpy using pip
-- install the requirements of etpclient-python
-    - etpclient-python uses poetry. One option is to manually pip-install its requirements(?)
-- obtain the patched version of etpclient-python and add it to PYTHONPATH
-    - The patches are hosted in the [Equinor fork of etpclient-python](https://github.com/equinor/etpclient-python/tree/modifications_for_Grid2d_test).
-    - Add the patched etpclient-python in front of your PYTHONPATH to prefer it over any existing installed version.
+To test this roundtrip locally do the following (assuming that some version of Python 3 and Docker is installed):
+- Run `docker compose up --detach` to set up the postgres database and the the ETP-server on localhost (this runs the [`compose.yaml`](compose.yaml)-file in this directory) in the background. This should take around 10-30 seconds.
+- Install the Python requirements with `pip install -r requirements.txt`. Alternatively, set up a virtual environment first before installing the requirements.
+
 
 ## Run the code
-Locate a xtgeo .gri file to be used in the test.  Update the input file .gri location at the top of the example code file resqpy_grid2d_roundtrip.py.  Run the code in resqpy_grid2d_roundtrip.py and verify the individual steps manually. 
+Locate a `xtgeo` `.gri`-file to be used in the test.
+Update the input file `.gri` location at the top of the example code file `resqpy_grid2d_roundtrip.py` with the path and name of your local file.
+Run the code via `python resqpy_grid2d_roundtrip.py` and verify the individual steps manually. 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,41 @@
+services:
+  open-etp-server:
+    image: community.opengroup.org:5555/osdu/platform/domain-data-mgmt-services/reservoir/open-etp-server/open-etp-server-v0-24-0
+    environment:
+      RDMS_DATA_PARTITION_MODE: "single"
+      RDMS_DATA_CONNECTIVITY_MODE: "osdu"
+      # Note that port, dbname, user and password are specified in the open-etp-postgres service
+      POSTGRESQL_CONN_STRING: "host=open-etp-postgres port=5432 dbname=kiwi user=testyuser password=testypass"
+    ports:
+      - 9002:9002
+    networks:
+      - web
+    depends_on:
+      open-etp-postgres:
+        # Wait until postgres server is ready
+        condition: service_healthy
+    # Run server with all authentication disabled
+    command: [ "openETPServer", "server", "--start", "--overwrite", "--authN", "none", "--authZ", "none" ]
+
+  open-etp-postgres:
+    image: postgres
+    ports:
+      - 5432:5432
+    environment:
+      # Set postgres username, password and database name
+      POSTGRES_PASSWORD: testypass
+      POSTGRES_USER: testyuser
+      POSTGRES_DB: kiwi
+    healthcheck:
+      # As we have set a user and database name, we need to specify this in the
+      # pg_isready-command for postgres when checking to see if the database is
+      # ready.
+      test: [ "CMD", "pg_isready", "-U", "testyuser", "-d", "kiwi" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - web
+
+networks:
+  web:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+h5py
+requests
+lxml
+xtgeo
+resqpy
+
+etpclient @ git+https://github.com/equinor/etpclient-python@modifications_for_Grid2d_test

--- a/resqpy_grid2d_roundtrip.py
+++ b/resqpy_grid2d_roundtrip.py
@@ -5,12 +5,13 @@ import time
 import json
 import argparse
 import pprint
+import pathlib
 
 import resqpy.model as rq
 import resqpy.crs as rcrs
 import resqpy.surface as rs
 
-from xtgeo.surface import RegularSurface
+import xtgeo
 
 from etpclient_helper import openWebSocket, getDataspaces, deleteDataspace, addDataspace, putDataObject, putDataObjectArray, getResources, getDataObject, getDataArray
 
@@ -20,8 +21,11 @@ from etpclient_helper import openWebSocket, getDataspaces, deleteDataspace, addD
 # Read the .gri file
 # NOTE: mysurf.yflip=1 means that positive z is down.  Not sure if/how this is to be indicated in the resqpy model.
 #
-input_gri_file = 'data/0.gri'
-mysurf = RegularSurface(input_gri_file)
+input_gri_file = pathlib.Path('data/0.gri')
+
+assert input_gri_file.exists(), "Add a test surface 0.gri under data"
+
+mysurf = xtgeo.surface_from_file(input_gri_file)
 nj,ni = mysurf.ncol, mysurf.nrow
 origin = (mysurf.xori, mysurf.yori, 0.0)
 di, dj = mysurf.xinc, mysurf.yinc

--- a/resqpy_grid2d_roundtrip.py
+++ b/resqpy_grid2d_roundtrip.py
@@ -79,22 +79,22 @@ mesh_uuid = model2.uuid(obj_type = 'Grid2dRepresentation', title = 'test_from_gr
 # Write the RESQML data to the ETP server
 # 
 
-# # Use with locally running open-etp-server 
-# args = {
-#     'host': '127.0.0.1',
-#     'port': '9002',
-#     'token': None
-# }
-
-# jwt_token = None
-jwt_token = "..."  # get token from azure CLI.  User must be part of the AAD group "rddms-users"
-
-
+# Use with locally running open-etp-server
 args = {
-    'host': 'interop-rddms.azure-api.net',
-    'port': '443',
-    'token': jwt_token
+    'host': '127.0.0.1',
+    'port': '9002',
+    'token': None
 }
+
+jwt_token = None
+# jwt_token = "..."  # get token from azure CLI.  User must be part of the AAD group "rddms-users"
+#
+#
+# args = {
+#     'host': 'interop-rddms.azure-api.net',
+#     'port': '443',
+#     'token': jwt_token
+# }
 
 
 wsm = openWebSocket(


### PR DESCRIPTION
This commit includes a `compose.yaml` for setting up an open-etp-server locally for testing. Furthermore, I have included a `.gitignore`, added a dummy `.gitkeep`-file under `data/` to ensure that the directory is there when cloning, switched to using localhost by default in the script, and updated the README.